### PR TITLE
[#10] feat: コンサル系サブグループ表示機能を追加

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -109,6 +109,20 @@ def _assign_category(name: str, categories: list[dict]) -> str:
     return 'その他'
 
 
+def _assign_subgroup(name: str, categories: list[dict]) -> str:
+    """コンサルティング・シンクタンクはサブグループに分割、それ以外は _assign_category と同じ。"""
+    category = _assign_category(name, categories)
+    if category != 'コンサルティング・シンクタンク':
+        return category
+    for cat in categories:
+        if cat['name'] == 'コンサルティング・シンクタンク':
+            for sg in cat.get('subgroups', []):
+                if name in set(sg.get('members', [])):
+                    return sg['name']
+            return 'コンサルティング（その他）'
+    return 'その他'
+
+
 df = _load_data()
 
 if df.empty:
@@ -139,6 +153,9 @@ with st.sidebar:
 
     st.divider()
     group_mode = st.toggle('カテゴリ別グループ表示', value=False)
+    subgroup_mode = False
+    if group_mode:
+        subgroup_mode = st.toggle('コンサル系サブグループ表示', value=False)
 
     if not group_mode:
         top_contractors = (
@@ -170,18 +187,27 @@ if not selected_years:
     st.stop()
 
 if group_mode:
+    caption_suffix = 'コンサル系サブグループ表示' if subgroup_mode else 'カテゴリ別グループ表示'
     st.caption(
         f'省庁: {selected_ministry}　／　'
-        f'対象年度: {len(selected_years)} 年度　／　カテゴリ別グループ表示'
+        f'対象年度: {len(selected_years)} 年度　／　{caption_suffix}'
     )
 
     categories = _load_groups().get('categories', [])
     work = filtered.copy()
-    work['_group'] = work['contractor_name'].apply(
-        lambda x: _assign_category(x, categories)
-    )
+    if subgroup_mode:
+        work['_group'] = work['contractor_name'].apply(
+            lambda x: _assign_subgroup(x, categories)
+        )
+        group_label = 'グループ'
+        chart_title = 'コンサル系サブグループ別 年度別受託件数の推移'
+    else:
+        work['_group'] = work['contractor_name'].apply(
+            lambda x: _assign_category(x, categories)
+        )
+        group_label = 'カテゴリ'
+        chart_title = 'カテゴリ別 年度別受託件数の推移'
     group_col = '_group'
-    group_label = 'カテゴリ'
     all_groups = sorted(work[group_col].unique().tolist())
 
     agg = (
@@ -193,7 +219,6 @@ if group_mode:
         [selected_years, all_groups],
         names=['fiscal_year', group_col],
     )
-    chart_title = 'カテゴリ別 年度別受託件数の推移'
 
 else:
     if not selected_contractors:


### PR DESCRIPTION
Close #10

## 変更内容の概要

- `config/groups.json` の `subgroups` フィールドを活用し、「コンサルティング・シンクタンク」カテゴリを5サブグループに細分化して可視化できるようにした
  - グローバルコンサル / Big4・監査系コンサル（コンサルティング部門）/ 国内系コンサル・シンクタンク / 地域シンクタンク / 市場調査・リサーチ会社
- サイドバーに「コンサル系サブグループ表示」トグルを追加（「カテゴリ別グループ表示」ON 時のみ表示されるよう制御）
- `_assign_subgroup()` を実装: コンサルティング・シンクタンク以外は `_assign_category` と同一挙動を保ち、コンサル系のみ `subgroups` を参照してサブグループ名を返す。`subgroups` いずれにも属さない場合は「コンサルティング（その他）」を返す

## 完了条件

- [x] サイドバーに「コンサル系サブグループ表示」トグルを追加する（カテゴリ別グループ表示 ON 時のみ表示）
- [x] コンサルティング・シンクタンクを5サブグループに分割して表示する
- [x] サブグループ未分類のコンサル系は「コンサルティング（その他）」に分類する
- [x] 他カテゴリはサブグループ表示 ON/OFF で変化しない
