### PR TITLE
[#14] 委託事業者マルチセレクトへの検索絞り込み機能の追加

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -167,36 +167,17 @@ with st.sidebar:
         )
         all_contractors = sorted(filtered['contractor_name'].unique().tolist())
 
-        search_query = st.text_input('事業者を検索', placeholder='事業者名を入力...')
-
         # 省庁が変わったら選択状態をリセット
         if st.session_state.get('_last_ministry') != selected_ministry:
             st.session_state['_last_ministry'] = selected_ministry
             st.session_state.pop('contractor_select', None)
 
-        # 現在の選択状態（有効な事業者のみに絞る）
-        current_selection = [
-            c for c in st.session_state.get('contractor_select', top_contractors)
-            if c in all_contractors
-        ]
-
-        # 検索文字列でオプションを絞り込む（大小文字・全半角区別なし）
-        if search_query:
-            search_filtered = [
-                c for c in all_contractors
-                if search_query.lower() in c.lower()
-            ]
-        else:
-            search_filtered = all_contractors
-
-        # 選択済み事業者は検索で消えないよう常にオプションに含める
-        multiselect_options = sorted(set(search_filtered) | set(current_selection))
-
         selected_contractors = st.multiselect(
-            '委託事業者（複数選択可）',
-            options=multiselect_options,
+            '委託事業者（複数選択可、入力で検索）',
+            options=all_contractors,
             default=top_contractors,
             key='contractor_select',
+            placeholder='事業者名を入力して絞り込み...',
         )
 
     st.divider()

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -166,10 +166,37 @@ with st.sidebar:
             .index.tolist()
         )
         all_contractors = sorted(filtered['contractor_name'].unique().tolist())
+
+        search_query = st.text_input('事業者を検索', placeholder='事業者名を入力...')
+
+        # 省庁が変わったら選択状態をリセット
+        if st.session_state.get('_last_ministry') != selected_ministry:
+            st.session_state['_last_ministry'] = selected_ministry
+            st.session_state.pop('contractor_select', None)
+
+        # 現在の選択状態（有効な事業者のみに絞る）
+        current_selection = [
+            c for c in st.session_state.get('contractor_select', top_contractors)
+            if c in all_contractors
+        ]
+
+        # 検索文字列でオプションを絞り込む（大小文字・全半角区別なし）
+        if search_query:
+            search_filtered = [
+                c for c in all_contractors
+                if search_query.lower() in c.lower()
+            ]
+        else:
+            search_filtered = all_contractors
+
+        # 選択済み事業者は検索で消えないよう常にオプションに含める
+        multiselect_options = sorted(set(search_filtered) | set(current_selection))
+
         selected_contractors = st.multiselect(
             '委託事業者（複数選択可）',
-            options=all_contractors,
+            options=multiselect_options,
             default=top_contractors,
+            key='contractor_select',
         )
 
     st.divider()


### PR DESCRIPTION
Close #14

## 変更内容の概要

- 当初は `st.text_input` による別置き検索ボックスを実装したが、入力のたびに Streamlit がページ全体を再レンダリングしてドロップダウンが閉じる問題が発生した。そのため **multiselect ネイティブの検索機能（クライアントサイドフィルタ）** を活用する方式に変更した
- multiselect のラベルを `委託事業者（複数選択可、入力で検索）` に変更し、`placeholder` を追加することで「クリック後にそのまま入力して絞り込む」操作を明示した
- `key='contractor_select'` でセッション状態を明示的に管理し、省庁変更時に選択状態を自動リセットする処理を追加した

## 完了条件

- [x] 委託事業者マルチセレクトで入力による検索絞り込みが動作する
- [x] 入力中にドロップダウンが閉じず、リアルタイムに候補が絞り込まれる
- [x] すでに選択済みの事業者は検索によって選択解除されない
- [x] 検索をクリアすると全事業者リストが表示される
- [x] group_mode ON のときは検索機能が表示されない（マルチセレクト自体が非表示のため）
- [x] 省庁を切り替えた際に選択状態がリセットされる
