### PR TITLE
[#18] ランキングページへの期間内集計メトリクス追加とメインページへの全事業者合計折れ線表示の実装

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -17,6 +17,7 @@ from src.data_pipeline.cleaner import clean_contractor_names, expand_multi_contr
 
 # データ不足のためデフォルトで非表示にする年度
 _DEFAULT_HIDDEN_YEARS = {2021}
+_TOTAL_LABEL = '全事業者合計'
 
 st.set_page_config(page_title='官公庁委託調査ダッシュボード', layout='wide')
 
@@ -174,7 +175,7 @@ with st.sidebar:
 
         selected_contractors = st.multiselect(
             '委託事業者（複数選択可、入力で検索）',
-            options=all_contractors,
+            options=[_TOTAL_LABEL] + all_contractors,
             default=top_contractors,
             key='contractor_select',
             placeholder='事業者名を入力して絞り込み...',
@@ -229,27 +230,47 @@ if group_mode:
     )
 
 else:
-    if not selected_contractors:
+    show_total = _TOTAL_LABEL in selected_contractors
+    real_contractors = [c for c in selected_contractors if c != _TOTAL_LABEL]
+
+    if not real_contractors and not show_total:
         st.warning('事業者を1社以上選択してください')
         st.stop()
 
-    st.caption(
-        f'省庁: {selected_ministry}　／　'
-        f'対象年度: {len(selected_years)} 年度　／　'
-        f'対象事業者: {len(selected_contractors)} 社'
-    )
+    caption_parts = [
+        f'省庁: {selected_ministry}',
+        f'対象年度: {len(selected_years)} 年度',
+    ]
+    if real_contractors:
+        caption_parts.append(f'対象事業者: {len(real_contractors)} 社')
+    if show_total:
+        caption_parts.append(_TOTAL_LABEL)
+    st.caption('　／　'.join(caption_parts))
 
     group_col = 'contractor_name'
     group_label = '委託事業者'
 
-    agg = (
-        filtered[filtered['contractor_name'].isin(selected_contractors)]
-        .groupby(['fiscal_year', 'contractor_name'])
-        .size()
-        .reset_index(name='件数')
-    )
+    frames = []
+    if real_contractors:
+        frames.append(
+            filtered[filtered['contractor_name'].isin(real_contractors)]
+            .groupby(['fiscal_year', 'contractor_name'])
+            .size()
+            .reset_index(name='件数')
+        )
+    if show_total:
+        total_per_year = (
+            filtered.groupby('fiscal_year')
+            .size()
+            .reset_index(name='件数')
+        )
+        total_per_year['contractor_name'] = _TOTAL_LABEL
+        frames.append(total_per_year)
+
+    agg = pd.concat(frames, ignore_index=True)
+    all_for_idx = real_contractors + ([_TOTAL_LABEL] if show_total else [])
     idx = pd.MultiIndex.from_product(
-        [selected_years, selected_contractors],
+        [selected_years, all_for_idx],
         names=['fiscal_year', 'contractor_name'],
     )
     chart_title = '委託事業者別 年度別受託件数の推移'

--- a/src/app/pages/01_TOPランキング.py
+++ b/src/app/pages/01_TOPランキング.py
@@ -111,6 +111,10 @@ else:
     year = int(selected_period.replace('年度', ''))
     target = base[base['fiscal_year'] == year]
 
+col1, col2 = st.columns(2)
+col1.metric('期間内の総受託件数', f'{len(target):,} 件')
+col2.metric('ユニーク事業者数', f'{target["contractor_name"].nunique():,} 社')
+
 ranking = (
     target.groupby('contractor_name')
     .size()


### PR DESCRIPTION
Close #18

## 変更内容の概要

- `src/app/pages/01_TOPランキング.py` に期間内集計メトリクスを追加した
  - 期間セレクタと連動して「期間内の総受託件数」「ユニーク事業者数」が2列メトリクスでテーブル上部に表示される
- `src/app/main.py` に「全事業者合計」折れ線表示機能を追加した
  - `_TOTAL_LABEL = '全事業者合計'` 定数を追加し、事業者マルチセレクトの選択肢先頭に配置した
  - 選択時は省庁・年度フィルター適用後の全事業者受託件数を年度別に集計した折れ線を描画する
  - 個別事業者との同時選択で合計線と個別線を重ねて表示できる

## 完了条件

- [x] `src/app/pages/01_TOPランキング.py` のテーブル上部に「期間内の総受託件数」「ユニーク事業者数」の2つのメトリクスを表示する
- [x] 期間セレクタを切り替えるとメトリクスの値が連動して変わる
- [x] `src/app/main.py` の事業者マルチセレクト選択肢の先頭に「全事業者合計」を追加する
- [x] 「全事業者合計」のみ選択した場合、全事業者合計の年度別折れ線が1本表示される
- [x] 「全事業者合計」と個別事業者を同時に選択した場合、合計線と個別線が同時に表示される
- [x] group_mode ON 時は「全事業者合計」は表示されない（マルチセレクト自体が非表示のため）
