### PR TITLE
[#21] feat: 招待トークン式ユーザー登録とメール認証機能を追加

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -16,3 +16,7 @@ services:
         sync: false
       - key: RESEND_FROM_EMAIL
         sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_KEY
+        sync: false

--- a/render.yaml
+++ b/render.yaml
@@ -12,3 +12,7 @@ services:
         sync: false
       - key: INVITE_TOKEN
         sync: false
+      - key: RESEND_API_KEY
+        sync: false
+      - key: RESEND_FROM_EMAIL
+        sync: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openpyxl>=3.1.0
 streamlit>=1.35.0
 plotly>=5.0.0
 resend>=2.0.0
+supabase>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.0.0
 openpyxl>=3.1.0
 streamlit>=1.35.0
 plotly>=5.0.0
+resend>=2.0.0

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -26,11 +26,19 @@ st.set_page_config(page_title='官公庁委託調査ダッシュボード', layo
 # --- 認証 ---
 
 def _authenticate(username: str, password: str) -> bool:
-    # Render 環境変数が設定されていれば優先して使用する
+    # 管理者アカウント（環境変数）
     env_user = os.environ.get('ADMIN_USERNAME')
     env_pass = os.environ.get('ADMIN_PASSWORD')
-    if env_user and env_pass:
-        return username == env_user and password == env_pass
+    if env_user and env_pass and username == env_user and password == env_pass:
+        return True
+    # 登録ユーザー（SQLite）
+    try:
+        from src.data_pipeline.user_store import authenticate_user
+        if authenticate_user(username, password):
+            return True
+    except Exception:
+        pass
+    # レガシー（auth.json）
     try:
         with open(_AUTH_PATH, encoding='utf-8') as f:
             users = json.load(f).get('users', {})

--- a/src/app/pages/01_top_ranking.py
+++ b/src/app/pages/01_top_ranking.py
@@ -20,10 +20,19 @@ st.set_page_config(page_title='TOP ランキング', layout='wide')
 # --- 認証 ---
 
 def _authenticate(username: str, password: str) -> bool:
+    # 管理者アカウント（環境変数）
     env_user = os.environ.get('ADMIN_USERNAME')
     env_pass = os.environ.get('ADMIN_PASSWORD')
-    if env_user and env_pass:
-        return username == env_user and password == env_pass
+    if env_user and env_pass and username == env_user and password == env_pass:
+        return True
+    # 登録ユーザー（SQLite）
+    try:
+        from src.data_pipeline.user_store import authenticate_user
+        if authenticate_user(username, password):
+            return True
+    except Exception:
+        pass
+    # レガシー（auth.json）
     try:
         with open(_AUTH_PATH, encoding='utf-8') as f:
             users = json.load(f).get('users', {})

--- a/src/app/pages/02_signup.py
+++ b/src/app/pages/02_signup.py
@@ -1,0 +1,82 @@
+import os
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from src.data_pipeline.user_store import add_user, email_exists, generate_credentials  # noqa: E402
+
+st.set_page_config(page_title='ユーザー登録', layout='centered')
+
+_DASHBOARD_URL = 'https://gov-commission-dashboard.onrender.com'
+_FROM_EMAIL = os.environ.get('RESEND_FROM_EMAIL', 'onboarding@resend.dev')
+
+
+def _send_credentials(to_email: str, username: str, password: str) -> bool:
+    api_key = os.environ.get('RESEND_API_KEY', '')
+    if not api_key:
+        return False
+    try:
+        import resend
+        resend.api_key = api_key
+        resend.Emails.send({
+            'from': _FROM_EMAIL,
+            'to': [to_email],
+            'subject': '【官公庁委託調査ダッシュボード】ログイン情報',
+            'html': (
+                '<p>官公庁委託調査ダッシュボードへのご登録ありがとうございます。</p>'
+                '<p>以下のログイン情報でアクセスできます。</p>'
+                '<table border="0" cellpadding="6">'
+                f'<tr><td>ユーザーID</td><td><strong>{username}</strong></td></tr>'
+                f'<tr><td>パスワード</td><td><strong>{password}</strong></td></tr>'
+                '</table>'
+                f'<br><p>ダッシュボード: <a href="{_DASHBOARD_URL}">{_DASHBOARD_URL}</a></p>'
+                '<p><small>このメールに心当たりがない場合は無視してください。</small></p>'
+            ),
+        })
+        return True
+    except Exception:
+        return False
+
+
+st.title('ユーザー登録')
+
+invite_token = st.query_params.get('invite', '')
+valid_token = os.environ.get('INVITE_TOKEN', '')
+
+if not valid_token:
+    st.error('招待トークンが設定されていません。管理者にお問い合わせください。')
+    st.stop()
+
+if invite_token != valid_token:
+    st.warning('このページにアクセスするには招待URLが必要です。')
+    st.stop()
+
+st.info('メールアドレスを入力すると、ダッシュボードのログイン用IDとパスワードをお送りします。')
+
+with st.form('signup_form'):
+    email = st.text_input('メールアドレス')
+    submitted = st.form_submit_button('登録してログイン情報を受け取る')
+
+if submitted:
+    email = email.strip()
+    if not email or '@' not in email:
+        st.error('有効なメールアドレスを入力してください。')
+    elif email_exists(email):
+        st.warning('このメールアドレスはすでに登録されています。')
+    else:
+        username, password = generate_credentials()
+        try:
+            add_user(username, password, email)
+        except Exception as e:
+            st.error(f'ユーザー登録に失敗しました: {e}')
+            st.stop()
+
+        if _send_credentials(email, username, password):
+            st.success(f'{email} にログイン情報をお送りしました。メールをご確認ください。')
+        else:
+            st.warning('メール送信に失敗しました（RESEND_API_KEY を確認してください）。以下のログイン情報を直接お使いください。')
+            st.code(f'ユーザーID: {username}\nパスワード: {password}')

--- a/src/data_pipeline/user_store.py
+++ b/src/data_pipeline/user_store.py
@@ -1,0 +1,60 @@
+import hashlib
+import secrets
+import sqlite3
+import string
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_USERS_DB_PATH = _PROJECT_ROOT / 'data' / 'processed' / 'users.sqlite'
+
+
+def _get_conn() -> sqlite3.Connection:
+    _USERS_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(_USERS_DB_PATH))
+    conn.execute('''
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            password_hash TEXT NOT NULL,
+            email TEXT UNIQUE NOT NULL,
+            created_at TEXT DEFAULT (datetime('now'))
+        )
+    ''')
+    conn.commit()
+    return conn
+
+
+def _hash(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def generate_credentials() -> tuple[str, str]:
+    username = 'user_' + secrets.token_hex(4)
+    password = ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(10))
+    return username, password
+
+
+def add_user(username: str, password: str, email: str) -> None:
+    conn = _get_conn()
+    conn.execute(
+        'INSERT INTO users (username, password_hash, email) VALUES (?, ?, ?)',
+        (username, _hash(password), email),
+    )
+    conn.commit()
+    conn.close()
+
+
+def authenticate_user(username: str, password: str) -> bool:
+    conn = _get_conn()
+    row = conn.execute(
+        'SELECT password_hash FROM users WHERE username = ?', (username,)
+    ).fetchone()
+    conn.close()
+    return row is not None and row[0] == _hash(password)
+
+
+def email_exists(email: str) -> bool:
+    conn = _get_conn()
+    row = conn.execute('SELECT 1 FROM users WHERE email = ?', (email,)).fetchone()
+    conn.close()
+    return row is not None

--- a/src/data_pipeline/user_store.py
+++ b/src/data_pipeline/user_store.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import secrets
 import sqlite3
 import string
@@ -8,7 +9,30 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _USERS_DB_PATH = _PROJECT_ROOT / 'data' / 'processed' / 'users.sqlite'
 
 
-def _get_conn() -> sqlite3.Connection:
+def _hash(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def generate_credentials() -> tuple[str, str]:
+    username = 'user_' + secrets.token_hex(4)
+    password = ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(10))
+    return username, password
+
+
+# --- Supabase（本番: Render） ---
+
+def _supabase():
+    url = os.environ.get('SUPABASE_URL')
+    key = os.environ.get('SUPABASE_KEY')
+    if not url or not key:
+        return None
+    from supabase import create_client
+    return create_client(url, key)
+
+
+# --- SQLite（ローカル開発用フォールバック） ---
+
+def _sqlite_conn() -> sqlite3.Connection:
     _USERS_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(_USERS_DB_PATH))
     conn.execute('''
@@ -24,37 +48,49 @@ def _get_conn() -> sqlite3.Connection:
     return conn
 
 
-def _hash(password: str) -> str:
-    return hashlib.sha256(password.encode()).hexdigest()
-
-
-def generate_credentials() -> tuple[str, str]:
-    username = 'user_' + secrets.token_hex(4)
-    password = ''.join(secrets.choice(string.ascii_letters + string.digits) for _ in range(10))
-    return username, password
-
+# --- 公開 API ---
 
 def add_user(username: str, password: str, email: str) -> None:
-    conn = _get_conn()
-    conn.execute(
-        'INSERT INTO users (username, password_hash, email) VALUES (?, ?, ?)',
-        (username, _hash(password), email),
-    )
-    conn.commit()
-    conn.close()
+    client = _supabase()
+    if client:
+        client.table('users').insert({
+            'username': username,
+            'password_hash': _hash(password),
+            'email': email,
+        }).execute()
+    else:
+        conn = _sqlite_conn()
+        conn.execute(
+            'INSERT INTO users (username, password_hash, email) VALUES (?, ?, ?)',
+            (username, _hash(password), email),
+        )
+        conn.commit()
+        conn.close()
 
 
 def authenticate_user(username: str, password: str) -> bool:
-    conn = _get_conn()
-    row = conn.execute(
-        'SELECT password_hash FROM users WHERE username = ?', (username,)
-    ).fetchone()
-    conn.close()
-    return row is not None and row[0] == _hash(password)
+    client = _supabase()
+    if client:
+        result = client.table('users').select('password_hash').eq('username', username).execute()
+        if not result.data:
+            return False
+        return result.data[0]['password_hash'] == _hash(password)
+    else:
+        conn = _sqlite_conn()
+        row = conn.execute(
+            'SELECT password_hash FROM users WHERE username = ?', (username,)
+        ).fetchone()
+        conn.close()
+        return row is not None and row[0] == _hash(password)
 
 
 def email_exists(email: str) -> bool:
-    conn = _get_conn()
-    row = conn.execute('SELECT 1 FROM users WHERE email = ?', (email,)).fetchone()
-    conn.close()
-    return row is not None
+    client = _supabase()
+    if client:
+        result = client.table('users').select('id').eq('email', email).execute()
+        return len(result.data) > 0
+    else:
+        conn = _sqlite_conn()
+        row = conn.execute('SELECT 1 FROM users WHERE email = ?', (email,)).fetchone()
+        conn.close()
+        return row is not None


### PR DESCRIPTION
Close #21

## 変更内容の概要

- `src/data_pipeline/user_store.py` を新規追加
  - Supabase（無料 PostgreSQL）をユーザーストアとして採用（Render 無料プランの ephemeral storage 制約に対応）
  - `SUPABASE_URL` / `SUPABASE_KEY` 未設定時は SQLite にフォールバック（ローカル開発用）
  - パスワードは SHA-256 でハッシュ化して保存
- `src/app/pages/02_signup.py` を新規追加
  - 招待トークン付き URL（`?invite=TOKEN`）でのみアクセス可能な登録ページ
  - メールアドレスを入力するとランダム生成した ID/PW を Resend 経由で送信
  - メール送信失敗時は画面上に ID/PW を表示するフォールバックあり
- `_authenticate()` を更新（`main.py` / `01_top_ranking.py`）
  - 認証順: 管理者ENV変数 → Supabase 登録ユーザー → auth.json（レガシー）
- `requirements.txt` に `resend>=2.0.0` / `supabase>=2.0.0` を追加
- `render.yaml` に `RESEND_API_KEY` / `RESEND_FROM_EMAIL` / `SUPABASE_URL` / `SUPABASE_KEY` を追加

## 完了条件

- [x] 招待 URL（`?invite=TOKEN`）でのみ登録ページにアクセスできる
- [x] メールアドレス入力 → ID/PW 自動生成 → Resend でメール送信
- [x] メール送信失敗時にフォールバックで画面表示
- [x] 登録ユーザーが Supabase に永続保存される（Render 再デプロイ後も維持）
- [x] 登録ユーザーが通常のログインフォームで認証できる
- [x] 管理者アカウント（ENV変数）は引き続き利用可能
