### PR TITLE
[#25] feat: 受託シェア(%)表示モードをメインページに追加

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -297,14 +297,29 @@ chart_df = (
     .sort_values([group_col, 'fiscal_year'])
 )
 
+# 省庁全体の年度別件数を分母としてシェア(%)を計算
+year_totals = filtered.groupby('fiscal_year').size().reset_index(name='_total')
+chart_df = chart_df.merge(year_totals, on='fiscal_year', how='left')
+chart_df['シェア(%)'] = (chart_df['件数'] / chart_df['_total'] * 100).round(1).fillna(0)
+
+# 表示形式の切り替え
+display_mode = st.radio('表示形式', ['件数', 'シェア(%)'], horizontal=True)
+
+if display_mode == 'シェア(%)':
+    y_col = 'シェア(%)'
+    plot_title = chart_title.replace('受託件数', '受託シェア(%)')
+else:
+    y_col = '件数'
+    plot_title = chart_title
+
 fig = px.line(
     chart_df,
     x='fiscal_year',
-    y='件数',
+    y=y_col,
     color=group_col,
     markers=True,
-    title=chart_title,
-    labels={'fiscal_year': '年度', group_col: group_label},
+    title=plot_title,
+    labels={'fiscal_year': '年度', group_col: group_label, y_col: y_col},
 )
 fig.update_xaxes(dtick=1, tickformat='d')
 fig.update_layout(legend_title_text=group_label)
@@ -312,10 +327,11 @@ st.plotly_chart(fig, use_container_width=True)
 
 with st.expander('集計データを表示'):
     pivot = (
-        chart_df.pivot(index=group_col, columns='fiscal_year', values='件数')
+        chart_df.pivot(index=group_col, columns='fiscal_year', values=y_col)
         .fillna(0)
-        .astype(int)
     )
+    if display_mode == '件数':
+        pivot = pivot.astype(int)
     pivot.index.name = group_label
     pivot.columns.name = '年度'
     st.dataframe(pivot, use_container_width=True)


### PR DESCRIPTION
Close #25

## 変更内容の概要

- `src/app/main.py` のグラフ描画セクションに「表示形式」ラジオボタンを追加
  - 件数（絶対値）とシェア(%)をワンクリックで切り替え可能
  - シェア = 企業の年度受託件数 ÷ 省庁全体の年度受託件数 × 100
- 個別事業者モード・カテゴリ別・コンサル系サブグループ別の全モードに対応
- グラフタイトル・Y軸ラベルも表示モードに応じて自動更新
- 集計テーブル（エキスパンダー内）も同様にシェア値に切り替わる

なぜこの変更が必要か: 省庁全体の発注件数が年度によって増減するため、絶対値だけでは
企業の競争力の変化を正確に読み取れない。シェア表示により、市場全体に対する
相対的なポジション変化が把握しやすくなる。

## 完了条件

- [x] 件数 / シェア(%) を切り替えるラジオボタンをグラフ上部に設置する
- [x] シェアは対象年度の省庁全体発注件数を分母として計算する
- [x] グラフのY軸ラベル・タイトルが表示モードに応じて変わる
- [x] カテゴリ別・サブグループ別でもシェア表示が正しく動作する
- [x] 集計テーブルの値もシェア表示に切り替わる
