### PR TITLE
[#24] feat: メール送信を Gmail SMTP に切り替えてセキュリティを改善

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,9 +12,9 @@ services:
         sync: false
       - key: INVITE_TOKEN
         sync: false
-      - key: RESEND_API_KEY
+      - key: GMAIL_USER
         sync: false
-      - key: RESEND_FROM_EMAIL
+      - key: GMAIL_APP_PASSWORD
         sync: false
       - key: SUPABASE_URL
         sync: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ pandas>=2.0.0
 openpyxl>=3.1.0
 streamlit>=1.35.0
 plotly>=5.0.0
-resend>=2.0.0
 supabase>=2.0.0

--- a/src/app/pages/02_signup.py
+++ b/src/app/pages/02_signup.py
@@ -1,5 +1,8 @@
 import os
+import smtplib
 import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 from pathlib import Path
 
 import streamlit as st
@@ -7,37 +10,38 @@ import streamlit as st
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_PROJECT_ROOT))
 
-from src.data_pipeline.user_store import add_user, email_exists, generate_credentials  # noqa: E402
+from src.data_pipeline.user_store import add_user, delete_user, email_exists, generate_credentials  # noqa: E402
 
 st.set_page_config(page_title='ユーザー登録', layout='centered')
 
 _DASHBOARD_URL = 'https://gov-commission-dashboard.onrender.com'
-_FROM_EMAIL = os.environ.get('RESEND_FROM_EMAIL', 'onboarding@resend.dev')
 
 
 def _send_credentials(to_email: str, username: str, password: str) -> bool:
-    api_key = os.environ.get('RESEND_API_KEY', '')
-    if not api_key:
+    gmail_user = os.environ.get('GMAIL_USER', '')
+    gmail_app_password = os.environ.get('GMAIL_APP_PASSWORD', '')
+    if not gmail_user or not gmail_app_password:
         return False
     try:
-        import resend
-        resend.api_key = api_key
-        resend.Emails.send({
-            'from': _FROM_EMAIL,
-            'to': [to_email],
-            'subject': '【官公庁委託調査ダッシュボード】ログイン情報',
-            'html': (
-                '<p>官公庁委託調査ダッシュボードへのご登録ありがとうございます。</p>'
-                '<p>以下のログイン情報でアクセスできます。</p>'
-                '<table border="0" cellpadding="6">'
-                f'<tr><td>ユーザーID</td><td><strong>{username}</strong></td></tr>'
-                f'<tr><td>パスワード</td><td><strong>{password}</strong></td></tr>'
-                '</table>'
-                f'<br><p>上記のユーザーIDとパスワードを使って、以下のURLからログインしてください。</p>'
-                f'<p><a href="{_DASHBOARD_URL}">{_DASHBOARD_URL}</a></p>'
-                '<p><small>このメールに心当たりがない場合は無視してください。</small></p>'
-            ),
-        })
+        msg = MIMEMultipart('alternative')
+        msg['Subject'] = '【官公庁委託調査ダッシュボード】ログイン情報'
+        msg['From'] = gmail_user
+        msg['To'] = to_email
+        html = (
+            '<p>官公庁委託調査ダッシュボードへのご登録ありがとうございます。</p>'
+            '<p>以下のログイン情報でアクセスできます。</p>'
+            '<table border="0" cellpadding="6">'
+            f'<tr><td>ユーザーID</td><td><strong>{username}</strong></td></tr>'
+            f'<tr><td>パスワード</td><td><strong>{password}</strong></td></tr>'
+            '</table>'
+            '<br><p>上記のユーザーIDとパスワードを使って、以下のURLからログインしてください。</p>'
+            f'<p><a href="{_DASHBOARD_URL}">{_DASHBOARD_URL}</a></p>'
+            '<p><small>このメールに心当たりがない場合は無視してください。</small></p>'
+        )
+        msg.attach(MIMEText(html, 'html'))
+        with smtplib.SMTP_SSL('smtp.gmail.com', 465) as server:
+            server.login(gmail_user, gmail_app_password)
+            server.sendmail(gmail_user, to_email, msg.as_string())
         return True
     except Exception:
         return False
@@ -79,5 +83,9 @@ if submitted:
         if _send_credentials(email, username, password):
             st.success(f'{email} にログイン情報をお送りしました。メールをご確認ください。')
         else:
-            st.warning('メール送信に失敗しました（RESEND_API_KEY を確認してください）。以下のログイン情報を直接お使いください。')
-            st.code(f'ユーザーID: {username}\nパスワード: {password}')
+            # メール送信失敗時はユーザーを削除してロールバック
+            delete_user(email)
+            st.error(
+                'メール送信に失敗しました。しばらく待ってから再度お試しください。'
+                '問題が続く場合は管理者にお問い合わせください。'
+            )

--- a/src/data_pipeline/user_store.py
+++ b/src/data_pipeline/user_store.py
@@ -94,3 +94,14 @@ def email_exists(email: str) -> bool:
         row = conn.execute('SELECT 1 FROM users WHERE email = ?', (email,)).fetchone()
         conn.close()
         return row is not None
+
+
+def delete_user(email: str) -> None:
+    client = _supabase()
+    if client:
+        client.table('users').delete().eq('email', email).execute()
+    else:
+        conn = _sqlite_conn()
+        conn.execute('DELETE FROM users WHERE email = ?', (email,))
+        conn.commit()
+        conn.close()


### PR DESCRIPTION
Close #24

## 変更内容の概要

- `src/app/pages/02_signup.py` のメール送信処理を Resend → Gmail SMTP に切り替え
  - Python 標準ライブラリ `smtplib` を使用（追加パッケージ不要）
  - ドメイン取得なしで実ユーザーの任意メールアドレスへ送信可能
- メール送信失敗時の挙動を変更（セキュリティ改善）
  - 旧: 画面にID/PWをそのまま表示（未認証ユーザーが取得できてしまう問題）
  - 新: Supabase のユーザーレコードをロールバック削除してエラー表示
- `src/data_pipeline/user_store.py` に `delete_user()` 関数を追加
- `requirements.txt` から `resend>=2.0.0` を削除
- `render.yaml` の環境変数を `RESEND_*` → `GMAIL_USER` / `GMAIL_APP_PASSWORD` に更新

なぜこの変更が必要か: 旧実装ではメール送信が機能しない状態でも画面にID/PWが
表示されていたため、招待URLを知っていれば誰でも架空のメアドで登録・ログインできる
セキュリティ上の問題があった。

## 完了条件

- [x] 任意のメールアドレスにログイン情報が届く
- [x] メール送信失敗時は画面にID/PWを表示せずユーザー登録をロールバックする
- [x] ドメイン取得・有料サービス契約なしで実現する
- [x] `resend` パッケージへの依存を除去する
