### PR TITLE
[#28] feat: ログイン・アカウント作成時に画面全体のローディング表示を追加

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import pandas as pd
@@ -57,6 +58,8 @@ def _show_login() -> None:
         if st.form_submit_button('ログイン'):
             if _authenticate(username, password):
                 st.session_state['authenticated'] = True
+                with st.spinner('ログイン中... 画面が切り替わるまで5〜10秒程度かかる場合があります'):
+                    time.sleep(1)
                 st.rerun()
             else:
                 st.error('IDまたはパスワードが正しくありません')

--- a/src/app/pages/01_top_ranking.py
+++ b/src/app/pages/01_top_ranking.py
@@ -2,6 +2,7 @@ import json
 import os
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import pandas as pd
@@ -54,6 +55,8 @@ if not st.session_state['authenticated']:
         if st.form_submit_button('ログイン'):
             if _authenticate(username, password):
                 st.session_state['authenticated'] = True
+                with st.spinner('ログイン中... 画面が切り替わるまで5〜10秒程度かかる場合があります'):
+                    time.sleep(1)
                 st.rerun()
             else:
                 st.error('IDまたはパスワードが正しくありません')

--- a/src/app/pages/02_signup.py
+++ b/src/app/pages/02_signup.py
@@ -46,8 +46,9 @@ if submitted:
         st.warning('このメールアドレスはすでに登録されています。')
     else:
         try:
-            # username にメールアドレスを使用することでログイン時にメアドで入力可能にする
-            add_user(email, password, email)
+            with st.spinner('アカウントを作成中...'):
+                # username にメールアドレスを使用することでログイン時にメアドで入力可能にする
+                add_user(email, password, email)
         except Exception as e:
             st.error(f'登録に失敗しました: {e}')
             st.stop()


### PR DESCRIPTION
## 概要

ログイン・アカウント作成後のページ遷移中に、画面全体にローディング表示を追加した。
Render の起動に5〜10秒かかる場合でも、ユーザーが待機中と認識できるようになる。

## 変更内容

- `src/app/main.py`: ログイン成功後に `st.spinner` でローディングメッセージを表示してから `st.rerun()` を呼ぶように変更
- `src/app/pages/01_top_ranking.py`: 同上
- `src/app/pages/02_signup.py`: アカウント作成処理（Supabase への書き込み）中に `st.spinner` を表示

## 動作確認

- [ ] ローカルでログインし、スピナーと「画面が切り替わるまで5〜10秒程度かかる場合があります」のメッセージが表示されることを確認
- [ ] アカウント作成フォーム送信時に「アカウントを作成中...」スピナーが表示されることを確認

## 関連 Issue

Closes #28
